### PR TITLE
Color health bars by threat status

### DIFF
--- a/Localization.lua
+++ b/Localization.lua
@@ -13,7 +13,8 @@ Localization["enUS"] = {
 	ShowBuffsTooltip = "Show important buffs and debuffs on nameplates",
 	ShowClassResource = "Show class-specific combat resources",
 	ShowClassResourceTooltip = "Show combo points, runes, holy power, etc.",
-	Subtext = "These options let you change the appearance of unit nameplates"
+	Subtext = "These options let you change the appearance of unit nameplates",
+	ColorByThreatStatus = "Color health bars by threat status"
 }
 
 --[[
@@ -41,6 +42,7 @@ function NephilistNameplates:SetAllTheText()
 	optionsPanel.showBuffsButton.Text:SetText(strings.ShowBuffs);
 	optionsPanel.onlyShowOwnBuffsButton.Text:SetText(strings.OnlyShowOwnBuffs);
 	optionsPanel.hideClassBarButton.Text:SetText(strings.HideClassBar);
+	optionsPanel.colorByThreatStatusButton.Text:SetText(strings.ColorByThreatStatus);
 end
 
 

--- a/NephilistNameplates.lua
+++ b/NephilistNameplates.lua
@@ -358,6 +358,8 @@ function UnitFrame:UpdateHealthColor()
 	local healthBar = self.healthBar;
 	local options = self.optionTable;
 	local unit = self.unit;
+	local threatStatus = UnitThreatSituation("player", unit);
+	local colorByThreat = NephilistNameplatesOptions.ColorByThreatStatus;
 	local r, g, b;
 	if ( not UnitIsConnected(unit) ) then
 		r, g, b = 0.7, 0.7, 0.7;
@@ -372,6 +374,10 @@ function UnitFrame:UpdateHealthColor()
 				r, g, b = classColor.r, classColor.g, classColor.b;
 			elseif ( self:IsTapDenied() ) then
 				r, g, b = 0.3, 0.3, 0.3;
+			elseif (threatStatus == 3 and colorByThreat) then
+				r, g, b = 0.23, 0.51, 1;
+			elseif (threatStatus == 2 and colorByThreat) then
+				r, g, b = 1, 0.68, 0;
 			elseif ( options.colorHealthBySelection ) then
 				-- Use color based on the type of unit (neutral, etc.)
 				if ( options.considerSelectionInCombatAsHostile and IsOnThreatList(self.displayedUnit) ) then

--- a/Options.lua
+++ b/Options.lua
@@ -37,7 +37,8 @@ local hideClassBarButton = optionsPanel.hideClassBarButton;
 hideClassBarButton:SetPoint("TOPLEFT", optionsPanel.onlyShowOwnBuffsButton, "BOTTOMLEFT", 0, -12);
 -- hideClassBarButton.onValueChanged = function() end
 
-
-
+optionsPanel.colorByThreatStatusButton = optionsPanel:CreateCheckButton("ColorByThreatStatus");
+local colorByThreatStatusButton = optionsPanel.colorByThreatStatusButton;
+colorByThreatStatusButton:SetPoint("TOPLEFT", optionsPanel.hideClassBarButton, "BOTTOMLEFT", 0, -12);
 
 


### PR DESCRIPTION
This update adds an option to colour health bars by threat status. This is essential for tanks to get a quick overview of which targets are currently on them and (more importantly) which aren't. Units completely fixed on the player are marked as blue bars. Units that are about to switch to another target have yellow bars. Units currently targeting someone else have red bars.

The colours could be subject to change or possibly even configurable in the future.